### PR TITLE
Add xpm dependency

### DIFF
--- a/major-mode-icons.el
+++ b/major-mode-icons.el
@@ -1,7 +1,7 @@
 ;;; major-mode-icons.el --- display icon for major-mode on mode-line.
 
 ;; Authors: stardiviner <numbchild@gmail.com>
-;; Package-Requires: ((emacs "24.3") (powerline "2.4") (all-the-icons "2.3.0"))
+;; Package-Requires: ((emacs "24.3") (powerline "2.4") (xpm "1.0.4") (all-the-icons "2.3.0"))
 ;; Version: 0.2
 ;; Keywords: frames multimedia
 ;; homepage: http://github.com/stardiviner/major-mode-icons

--- a/major-mode-icons.el
+++ b/major-mode-icons.el
@@ -48,14 +48,13 @@
   :group 'major-mode-icons
   :type 'string)
 
-;;;###autoload
 (defcustom major-mode-icons-icons-style 'xpm
   "Use `all-the-icons' package to show major mode icons.
 
 If set to symbol `all-the-icons' then use `all-the-icons'.
 Otherwise symbol `xpm' to use built-in xpm image files."
   :group 'major-mode-icons
-  :type 'string)
+  :type 'symbol)
 
 ;; major mode with icon
 (defvar major-mode-icons--major-mode-list

--- a/major-mode-icons.el
+++ b/major-mode-icons.el
@@ -24,6 +24,8 @@
 
 (require 'cl-lib)
 (require 'powerline)
+(require 'xpm)
+(require 'all-the-icons)
 
 (defgroup major-mode-icons nil
   "Show icon for current buffer's major-mode."
@@ -54,10 +56,6 @@ If set to symbol `all-the-icons' then use `all-the-icons'.
 Otherwise symbol `xpm' to use built-in xpm image files."
   :group 'major-mode-icons
   :type 'string)
-
-(require (pcase major-mode-icons-icons-style
-           (`all-the-icons 'all-the-icons)
-           (`xpm 'xpm)))
 
 ;; major mode with icon
 (defvar major-mode-icons--major-mode-list


### PR DESCRIPTION
Hi!
I face below error when I install from MELPA.

``` emacs-lisp
Debugger entered--Lisp error: (file-missing "Cannot open load file" "No such
  require(xpm)
  eval-buffer(#<buffer  *load*-547053> nil "/home/conao/.emacs.d/local/26.3/e
  load-with-code-conversion("/home/conao/.emacs.d/local/26.3/elpa/major-mode-
  (major-mode-icons--major-mode-list-match)
  (let* ((match (major-mode-icons--major-mode-list-match)) (icon (cdr match))
  (cond ((memql major-mode-icons-icons-style (quote (\` all-the-icons))) (all
  (defvar major-mode-icons-lighter (cond ((memql major-mode-icons-icons-style
  eval-buffer(#<buffer  *load*> nil "/home/conao/.emacs.d/local/26.3/elpa/maj
  load-with-code-conversion("/home/conao/.emacs.d/local/26.3/elpa/major-mode-
  load("/home/conao/.emacs.d/local/26.3/elpa/major-mode-icons-20170301.714/ma
  package--activate-autoloads-and-load-path(#s(package-desc :name major-mode-
  package--load-files-for-activation(#s(package-desc :name major-mode-icons :
  package-activate-1(#s(package-desc :name major-mode-icons :version (2017030
  package-unpack(#s(package-desc :name major-mode-icons :version (20170301 71
  #f(compiled-function (&optional good-sigs) #<bytecode 0xf49cf9>)(nil)
  package--check-signature("https://melpa.org/packages/" "major-mode-icons-20
  package-install-from-archive(#s(package-desc :name major-mode-icons :versio
  mapc(package-install-from-archive (#s(package-desc :name powerline :version
  package-download-transaction((#s(package-desc :name powerline :version (202
  package-install(major-mode-icons)
  (condition-case _err (package-install (quote major-mode-icons)) (error (con
  (if (package-installed-p (quote major-mode-icons)) nil (if (assoc (quote ma
  (progn (if (package-installed-p (quote major-mode-icons)) nil (if (assoc (q
  (condition-case err (progn (if (package-installed-p (quote major-mode-icons
  (prog1 (quote major-mode-icons) (condition-case err (progn (if (package-ins
  (progn (prog1 (quote major-mode-icons) (condition-case err (progn (if (pack
  eval((progn (prog1 (quote major-mode-icons) (condition-case err (progn (if
  elisp--eval-last-sexp(nil)
  #f(compiled-function (eval-last-sexp-arg-internal) "Evaluate sexp before po
  ad-Advice-eval-last-sexp(#f(compiled-function (eval-last-sexp-arg-internal)
  apply(ad-Advice-eval-last-sexp #f(compiled-function (eval-last-sexp-arg-int
  eval-last-sexp(nil)
  funcall-interactively(eval-last-sexp nil)
  call-interactively(eval-last-sexp nil nil)
  command-execute(eval-last-sexp)
```

I think `xpm` dependency specification is missing.